### PR TITLE
fix(footer): wire up Privacy, Terms and Data deletion links

### DIFF
--- a/src/app/components/Footer.tsx
+++ b/src/app/components/Footer.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+
 const columns = [
   {
     heading: "Links",
@@ -68,12 +70,15 @@ export function Footer() {
             <a className="transition-colors hover:text-foreground" href="mailto:info@solafidei.com">
               info@solafidei.com
             </a>
-            <a className="transition-colors hover:text-foreground" href="#">
+            <Link className="transition-colors hover:text-foreground" href="/privacy">
               Privacy
-            </a>
-            <a className="transition-colors hover:text-foreground" href="#">
+            </Link>
+            <Link className="transition-colors hover:text-foreground" href="/terms">
               Terms
-            </a>
+            </Link>
+            <Link className="transition-colors hover:text-foreground" href="/data-deletion">
+              Data deletion
+            </Link>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Problem

The footer's **Privacy** and **Terms** links were `href="#"` placeholders. The pages at `/privacy` and `/terms` existed and rendered fine, but nothing on the site linked to them. `/data-deletion` had no inbound link at all — that one matters for Meta/Google app review submissions.

## Fix

Point all three at their real routes using `next/link`. 9 lines in one file.

## Verification

`next build` prerenders all 12 routes clean; `npm run lint` passes (one pre-existing `<img>` warning in vendored `LogoLoop.tsx`). Served the production build and checked every route:

| Route | Status |
|---|---|
| `/` | 200 |
| `/privacy` | 200 |
| `/terms` | 200 |
| `/data-deletion` | 200 |
| `/blog` | 200 |
| `/letter` | 200 |
| `/nope` (404 control) | 404 |

All three legal pages render their `<h1>` and have working back-to-home links. Every Nav/Footer anchor (`#home #services #work #about #benefits #faq #contact`) resolves to a real section id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Data Deletion link to the footer.
  * Updated Privacy and Terms links for improved in-app navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->